### PR TITLE
v0.3.0

### DIFF
--- a/lua/config/mappings.lua
+++ b/lua/config/mappings.lua
@@ -1,5 +1,8 @@
 require("modules.util")
 
+local autowrap = require("modules.autowrap")
+local comment = require("modules.comments")
+
 -- leader key
 vim.g.mapleader = ","
 
@@ -25,84 +28,14 @@ map('i', "'", "''<Esc>ha")
 map('i', "`", "``<Esc>ha")
 
 -- pair completion via word selection
-local function get_selection_range()
-    return vim.fn.getpos("'<"), vim.fn.getpos("'>")
-end
-
-local function wrap_selected(start_pos, end_pos, opening, closing)
-    local start_line, start_col = start_pos[2], start_pos[3]
-    local end_line, end_col = end_pos[2], end_pos[3] + 1
-
-    if start_line == end_line then
-        local line = vim.fn.getline(start_line)
-        local before = line:sub(1, start_col - 1)
-        local selected = line:sub(start_col, end_col - 1)
-        local after = line:sub(end_col)
-        vim.fn.setline(start_line, before .. opening .. selected .. closing .. after)
-    end
-end
-
-function _G.wrap_visual(wrapper)
-    local start_pos, end_pos = get_selection_range()
-    wrap_selected(start_pos, end_pos, wrapper, wrapper)
-    vim.cmd("normal! gv")
-end
-
-function _G.wrap_paired_visual(opening, closing)
-    local start_pos, end_pos = get_selection_range()
-    wrap_selected(start_pos, end_pos, opening, closing)
-    vim.cmd("normal! gv")
-end
-
-map('v', '<leader>"', ':lua wrap_visual(\'"\')<CR>')
-map('v', "<leader>'", ":lua wrap_visual(\"'\")<CR>")
-map('v', "<leader>(", ':lua wrap_paired_visual("(", ")")<CR>')
-map('v', "<leader>[", ':lua wrap_paired_visual("[", "]")<CR>')
-map('v', "<leader>{", ':lua wrap_paired_visual("{", "}")<CR>')
+vim.keymap.set('v', '<leader>"', function() autowrap.wrap('"') end, { noremap = true })
+vim.keymap.set('v', "<leader>'", function() autowrap.wrap("'") end, {})
+vim.keymap.set('v', "<leader>(", function() autowrap.wrap_paired("(", ")") end, {})
+vim.keymap.set('v', "<leader>[", function() autowrap.wrap_paired("[", "]") end, {})
+vim.keymap.set('v', "<leader>{", function() autowrap.wrap_paired("{", "}") end, {})
 
 -- commenting
-function _G.get_comment_token()
-    local filetype = vim.bo.filetype
-
-    if filetype == "python" or filetype == "elixir" then
-        return '# '
-    elseif filetype == "lua" then
-        return '-- '
-    else
-        return '// '
-    end
-end
-
-function _G.comment_normal()
-    local comment_token = get_comment_token()
-    local line = vim.api.nvim_get_current_line()
-    local indent = line:match("^%s*")
-    local new_line = indent .. comment_token .. line:sub(#indent + 1)
-    vim.api.nvim_set_current_line(new_line)
-end
-
-function _G.comment_undo_normal()
-    local comment_token = get_comment_token()
-    local line = vim.api.nvim_get_current_line()
-    local uncommented = line:gsub("^%s*" .. vim.pesc(comment_token), "")
-    vim.api.nvim_set_current_line(uncommented)
-end
-
-function _G.comment_visual()
-    local comment_token = vim.fn.escape(get_comment_token(), '/\\')
-
-    vim.cmd(string.format("'<,'>s/^/%s/", comment_token))
-    vim.cmd("noh")
-end
-
-function _G.comment_undo_visual()
-    local comment_token = get_comment_token()
-
-    vim.cmd(string.format("'<,'>s/^%s//", comment_token))
-    vim.cmd("noh")
-end
-
-map('n', "<leader>c", ":lua comment_normal()<CR>")
-map('n', "<leader>cu", ":lua comment_undo_normal()<CR>")
-map('v', "<leader>c", ":lua comment_visual()<CR>")
-map('v', "<leader>cu", ":lua comment_undo_visual()<CR>")
+vim.keymap.set('n', "<leader>c", comment.normal, {})
+vim.keymap.set('n', "<leader>cu", comment.undo_normal, {})
+vim.keymap.set('v', "<leader>c", comment.visual, {})
+vim.keymap.set('v', "<leader>cu", comment.undo_visual, {})

--- a/lua/modules/autowrap.lua
+++ b/lua/modules/autowrap.lua
@@ -1,0 +1,34 @@
+-- Autowrap Module
+--
+-- functions for selecting and wrapping selected words with character pairs,
+-- such as wrapping multiple lines with quotes, parentheses, etc.
+
+local function wrap_text(opening, closing)
+    local s_pos = vim.fn.getpos("v")
+    local e_pos = vim.fn.getpos(".")
+
+    -- swap positions when the direction of selection is backwards
+    if (s_pos[2] > e_pos[2]) or ((s_pos[2] == e_pos[2]) and (s_pos[3] > e_pos[3])) then
+        s_pos, e_pos = e_pos, s_pos
+    end
+
+    local selected_text = vim.api.nvim_buf_get_text(s_pos[1], s_pos[2] - 1, s_pos[3] - 1, e_pos[2] - 1, e_pos[3], {})
+    local wrapped_text = opening .. table.concat(selected_text, "\n") .. closing
+
+    vim.api.nvim_buf_set_text(s_pos[1], s_pos[2] - 1, s_pos[3] - 1, e_pos[2] - 1, e_pos[3], { wrapped_text })
+end
+
+local function wrap_visual(wrapper)
+    wrap_text(wrapper, wrapper)
+end
+
+local function wrap_paired_visual(opening, closing)
+    wrap_text(opening, closing)
+end
+
+local autowrap = {
+    wrap = wrap_visual,
+    wrap_paired = wrap_paired_visual
+}
+
+return autowrap

--- a/lua/modules/comments.lua
+++ b/lua/modules/comments.lua
@@ -1,0 +1,57 @@
+-- Comments Module
+
+-- Determine the appropriate comment token according to the buffer's filetype
+local function get_comment_token()
+    local filetype = vim.bo.filetype
+
+    if filetype == "python" or filetype == "elixir" then
+        return '# '
+    elseif filetype == "lua" then
+        return '-- '
+    else
+        return '// '
+    end
+end
+
+-- Comments a line in Normal Mode
+local function comment_normal()
+    local comment_token = get_comment_token()
+    local line = vim.api.nvim_get_current_line()
+    local indent = line:match("^%s*")
+    local new_line = indent .. comment_token .. line:sub(#indent + 1)
+    vim.api.nvim_set_current_line(new_line)
+end
+
+-- Removes comments for a line in Normal Mode
+local function comment_undo_normal()
+    local comment_token = get_comment_token()
+    local line = vim.api.nvim_get_current_line()
+    local uncommented = line:gsub("^%s*" .. vim.pesc(comment_token), "")
+    vim.api.nvim_set_current_line(uncommented)
+end
+
+-- Comments selected lines in Visual Mode
+local function comment_visual()
+    local comment_token = vim.fn.escape(get_comment_token(), '/\\')
+
+    vim.cmd(string.format("'<,'>s/^/%s/", comment_token))
+    vim.cmd("noh")
+end
+
+-- Removes comments for selected lines in Visual Mode
+local function comment_undo_visual()
+    local comment_token = get_comment_token()
+
+    vim.cmd(string.format("'<,'>s/^%s//", comment_token))
+    vim.cmd("noh")
+end
+
+
+local comments = {
+    normal = comment_normal,
+    undo_normal = comment_undo_normal,
+    visual = comment_visual,
+    undo_visual = comment_undo_visual
+}
+
+return comments


### PR DESCRIPTION
* updated wrapping feature (i.e. wrapping selected words in visual mode with braces, parentheses, and quotes)
  * wrapping-related functions are moved to `autowrap.lua`
  * `vim.fn.getpos()` calls are updated to reliably retrieve cursor positions in visual mode